### PR TITLE
SD-shuffle: adds secret shuffle animation to feature cards (cuz we can)

### DIFF
--- a/inertia/pages/home.vue
+++ b/inertia/pages/home.vue
@@ -5,17 +5,22 @@
       <p class="text-center text-3xl mt-2 mb-8 text-secondary-text">
         Discover the powerful features that make our app stand out.
       </p>
-      <div class="grid 2xl:grid-cols-3 sm:grid-cols-2">
+      <transition-group 
+        name="card-shuffle" 
+        tag="div" 
+        class="grid 2xl:grid-cols-3 sm:grid-cols-2"
+      >
         <div
-          v-for="(card, index) in featureCards"
-          :key="index"
+          v-for="card in featureCards"
+          :key="card.id"
           class="card flex flex-col justify-center items-center p-10 m-4 hover:scale-105 transition-transform duration-300"
+          @click="shuffleCards()"
         >
           <Icon class="text-9xl my-8 text-accent text-center" :icon="card.icon" />
           <p class="font-bold text-5xl text-center">{{ card.name }}</p>
           <p class="text-2xl mb-2 mt-6 text-center !text-secondary-text">{{ card.description }}</p>
         </div>
-      </div>
+      </transition-group>
     </div>
   </div>
 </template>
@@ -27,31 +32,37 @@ export default {
     return {
       featureCards: [
         {
+          id: 1,
           name: 'Group Creation',
           description: 'Create friend groups and manage members on the go.',
           icon: 'mdi:people',
         },
         {
+          id: 2,
           name: 'Organization',
           description: 'Add and categorize expenses with ease.',
           icon: 'eos-icons:organization',
         },
         {
+          id: 3,
           name: 'Multiple Groups',
           description: 'Split expenses among selectable group members.',
           icon: 'material-symbols:groups',
         },
         {
+          id: 4,
           name: 'Multi-Currency',
           description: 'Multi-currency support for international use.',
           icon: 'bi:currency-exchange',
         },
         {
+          id: 5,
           name: 'Real-Time Updates',
           description: 'Instantly see payment updates.',
           icon: 'tabler:clock-filled',
         },
         {
+          id: 6,
           name: 'Payment App Integration',
           description: 'Integration with Venmo and other payment platforms.',
           icon: 'si:credit-card-detailed-fill',
@@ -59,5 +70,19 @@ export default {
       ],
     }
   },
+  methods: {
+    shuffleCards() {
+      this.featureCards = this.featureCards
+        .map((card) => ({ card, sort: Math.random() }))
+        .sort((a, b) => a.sort - b.sort)
+        .map(({ card }) => card)
+    },
+  },
 }
 </script>
+
+<style scoped>
+.card-shuffle-move {
+  transition: transform 0.6s ease;
+}
+</style>

--- a/inertia/pages/home.vue
+++ b/inertia/pages/home.vue
@@ -72,10 +72,10 @@ export default {
   },
   methods: {
     shuffleCards() {
-      this.featureCards = this.featureCards
-        .map((card) => ({ card, sort: Math.random() }))
-        .sort((a, b) => a.sort - b.sort)
-        .map(({ card }) => card)
+      for (let i = this.featureCards.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [this.featureCards[i], this.featureCards[j]] = [this.featureCards[j], this.featureCards[i]];
+      }
     },
   },
 }

--- a/inertia/pages/home.vue
+++ b/inertia/pages/home.vue
@@ -13,12 +13,12 @@
         <div
           v-for="card in featureCards"
           :key="card.id"
-          class="card flex flex-col justify-center items-center p-10 m-4 hover:scale-105 transition-transform duration-300"
+          class="card flex flex-col justify-center items-center p-10 m-4 hover:cursor-pointer hover:scale-105 transition-transform duration-300"
           @click="shuffleCards()"
         >
           <Icon class="text-9xl my-8 text-accent text-center" :icon="card.icon" />
-          <p class="font-bold text-5xl text-center">{{ card.name }}</p>
-          <p class="text-2xl mb-2 mt-6 text-center !text-secondary-text">{{ card.description }}</p>
+          <p class="font-bold text-5xl text-center select-none">{{ card.name }}</p>
+          <p class="text-2xl mb-2 mt-6 text-center !text-secondary-text select-none">{{ card.description }}</p>
         </div>
       </transition-group>
     </div>


### PR DESCRIPTION
## Description

This ticket adds a shuffle animation to the feature cards to give the site some personality. 
## 🎫 Ticket

NO TICKET

## Related Pull Requests

## 🧪 Testing Instructions

```bash
git fetch --all
git checkout {{branch_name}}
npm run build
```
1. Go to the home page and click on any of the 6 shuffle cards
2. Ensure the animation works
## 📸 Screenshots (Optional)

## ✨ What's the context?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as intended)

## 🏎️ Quality check

- [ ] I have tested this code
- [ ] `npm run build` runs successfully?
- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?
